### PR TITLE
Remove unused light_group_id column from listing

### DIFF
--- a/db/migrate/20190111093036_remove_light_group_id_from_lights.rb
+++ b/db/migrate/20190111093036_remove_light_group_id_from_lights.rb
@@ -1,0 +1,5 @@
+class RemoveLightGroupIdFromLights < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :lights, :light_group_id, :integer
+  end
+end


### PR DESCRIPTION
Original database structure used a table called LightGroups which were the groups of lights. The revised structure uses a more clearly named table `groups` as well as a join table `light_groups` to allow for a many-to-many relationship between `lights` and `groups` (light can belong to "Dining Room, "Downstairs", and "All" at the same time), so the foreign_key column in the lights table is no longer needed.